### PR TITLE
LEARN Accelerators Page Updates

### DIFF
--- a/_infocomm-media-clubs-cca/LEARN: Tech and Media Courses/LEARN Accelerators.md
+++ b/_infocomm-media-clubs-cca/LEARN: Tech and Media Courses/LEARN Accelerators.md
@@ -12,7 +12,7 @@ and intensive programmes, supported by industry leaders. Students will
 undergo training over 6 to 10 months on weekends and school holidays where
 they will work on real-life challenges and develop practical tech solutions.</p>
 <h4>Upcoming Accelerators</h4>
-<p><strong>AWS Data Science Accelerator (Sec/JC)</strong>
+<p><strong>AWS Data Science Accelerator (Sec/JC)</strong> 
 <br>Commitment: 110 hours</p>
 <ul data-tight="true" class="tight">
 <li>
@@ -28,7 +28,7 @@ from AWS’ Cloud Practitioner Essentials.</p>
 <p>Sign Up <a href="https://go.gov.sg/aws-accel22" rel="noopener noreferrer nofollow" target="_blank">Now!</a> (Application
 ends 16 Feb 2024)</p>
 <p></p>
-<p><strong>Swift Accelerator (Sec/JC)</strong>
+<p><strong>Swift Accelerator (Sec/JC)</strong> 
 <br>Commitment: 180 hours</p>
 <ul data-tight="true" class="tight">
 <li>

--- a/_infocomm-media-clubs-cca/LEARN: Tech and Media Courses/LEARN Accelerators.md
+++ b/_infocomm-media-clubs-cca/LEARN: Tech and Media Courses/LEARN Accelerators.md
@@ -27,7 +27,7 @@ racing autonomous cars in a fun Deep Racer and pick up industry level knowledge
 from AWS’ Cloud Practitioner Essentials.</p>
 <p>Sign Up <a href="https://go.gov.sg/aws-accel22" rel="noopener noreferrer nofollow" target="_blank">Now!</a> (Application
 ends 16 Feb 2024)</p>
-<p>Register <a href="https://go.gov.sg/aws-accel22" rel="noopener noreferrer nofollow" target="_blank">Here</a>!</p>
+<p></p>
 <p><strong>Swift Accelerator (Sec/JC)</strong> 
 <br>Commitment: 180 hours</p>
 <ul data-tight="true" class="tight">

--- a/_infocomm-media-clubs-cca/LEARN: Tech and Media Courses/LEARN Accelerators.md
+++ b/_infocomm-media-clubs-cca/LEARN: Tech and Media Courses/LEARN Accelerators.md
@@ -27,7 +27,7 @@ racing autonomous cars in a fun Deep Racer and pick up industry level knowledge
 from AWS’ Cloud Practitioner Essentials.</p>
 <p>Sign Up <a href="https://go.gov.sg/aws-accel22" rel="noopener noreferrer nofollow" target="_blank">Now!</a> (Application
 ends 16 Feb 2024)</p>
-<p></p>
+<p>Register <a href="https://go.gov.sg/aws-accel22" rel="noopener noreferrer nofollow" target="_blank">Here</a>!</p>
 <p><strong>Swift Accelerator (Sec/JC)</strong> 
 <br>Commitment: 180 hours</p>
 <ul data-tight="true" class="tight">

--- a/_infocomm-media-clubs-cca/LEARN: Tech and Media Courses/LEARN Accelerators.md
+++ b/_infocomm-media-clubs-cca/LEARN: Tech and Media Courses/LEARN Accelerators.md
@@ -3,17 +3,41 @@ title: LEARN Accelerators
 permalink: /infocomm-media-clubs-cca/learn/accelerators/
 description: LEARN ACCELERATORS
 third_nav_title: "LEARN: Tech and Media Courses"
+variant: tiptap
 ---
-## LEARN Accelerators
-The LEARN Accelerators aim to provide Club members with opportunities to deepen their learning and understanding of tech and media through holistic and intensive programmes, supported by industry leaders. Students will undergo training over 6 to 10 months on weekends and school holidays where they will work on real-life challenges and develop practical tech solutions.
-
-#### Upcoming Accelerators
-
-**AWS Data Science Accelerator (Sec/JC)**<br>
-Commitment: 110 hours 
-* Nov 2022 to Aug 2023
-
-Acquire deep Data Science skills through designing and building solutions to solving real problem statements from partners. Students will learn the necessary machine learning and deep learning skills to design and build their own AI solutions. At the end of the Accelerator, students will obtain the foundational AWS Cloud Practitioner Essentials certification.
-
-
-Sign Up [Now!](https://go.gov.sg/aws-accel22)
+<h2>LEARN Accelerators</h2>
+<p>The LEARN Accelerators aim to provide Club members with opportunities
+to deepen their learning and understanding of tech and media through holistic
+and intensive programmes, supported by industry leaders. Students will
+undergo training over 6 to 10 months on weekends and school holidays where
+they will work on real-life challenges and develop practical tech solutions.</p>
+<h4>Upcoming Accelerators</h4>
+<p><strong>AWS Data Science Accelerator (Sec/JC)</strong>
+<br>Commitment: 110 hours</p>
+<ul data-tight="true" class="tight">
+<li>
+<p>Mar 2024 to Nov 2024</p>
+</li>
+</ul>
+<p>Acquire deep Data Science skills through designing and building solutions
+to solving real problem statements from partners. Students will learn the
+necessary machine learning and deep learning skills to design and build
+their own AI solutions. The students will also apply machine learning through
+racing autonomous cars in a fun Deep Racer and pick up industry level knowledge
+from AWS’ Cloud Practitioner Essentials.</p>
+<p>Sign Up <a href="https://go.gov.sg/aws-accel22" rel="noopener noreferrer nofollow" target="_blank">Now!</a> (Application
+ends 16 Feb 2024)</p>
+<p></p>
+<p><strong>Swift Accelerator (Sec/JC)</strong>
+<br>Commitment: 180 hours</p>
+<ul data-tight="true" class="tight">
+<li>
+<p>Mar 2024 to Nov 2024</p>
+</li>
+</ul>
+<p>The Swift Accelerator is an intensive talent development programme for
+secondary school and junior college students. Over 8 months, students learn
+to code in Swift, and apply story-telling and design thinking principles
+to design, build and release an iOS app of their own.</p>
+<p>Sign Up <a href="https://swiftinsg.org/join-us" rel="noopener noreferrer nofollow" target="_blank"><u>Now!</u></a> (Application
+ends 24 Feb 2024)</p>


### PR DESCRIPTION
Hi Diana,

Pull request created for the following changes to LEARN Accelerators web page:-

1) AWS Data Science Accelerator (Sec/JC)
Commitment: 110 hours
•	Mar 2024 to Nov 2024
Acquire deep Data Science skills through designing and building solutions to solving real problem statements from partners. Students will learn the necessary machine learning and deep learning skills to design and build their own AI solutions. The students will also apply machine learning through racing autonomous cars in a fun Deep Racer and pick up industry level knowledge from AWS’ Cloud Practitioner Essentials.
Sign Up Now! Application ends 16 Feb 2024.

2) Swift Accelerator (Sec/JC)
Commitment: 180 hours
•	Mar 2024 to Nov 2024
The Swift Accelerator is an intensive talent development programme for secondary school and junior college students. Over 8 months, students learn to code in Swift, and apply story-telling and design thinking principles to design, build and release an iOS app of their own.
Sign Up Now! Application ends 24 Feb 2024.

Thank you.

Winson