### PR TITLE
Amendments to LEARN Roadmaps webpage

### DIFF
--- a/_infocomm-media-clubs-cca/LEARN: Tech and Media Courses/LEARN Roadmaps.md
+++ b/_infocomm-media-clubs-cca/LEARN: Tech and Media Courses/LEARN Roadmaps.md
@@ -65,7 +65,7 @@ course application via these links:</p>
 </td>
 <td rowspan="1" colspan="1">
 <p>Pedro Agurre
-<br><a href="mailto:pedro@makethechange.sg" rel="noopener noreferrer nofollow" target="_blank">pedro@makethechange.sg</a>
+<br><a href="mailto:pedro@makethechange.sg" rel="noopener noreferrer nofollow" target="_blank">pedro@makethechange.sg</a> 
 <br>
 </p>
 </td>
@@ -81,7 +81,7 @@ course application via these links:</p>
 </td>
 <td rowspan="1" colspan="1">
 <p>Kenneth Sim
-<br><a href="mailto:kenneth@edm8ker.com" rel="noopener noreferrer nofollow" target="_blank">kenneth@edm8ker.com</a>
+<br><a href="mailto:kenneth@edm8ker.com" rel="noopener noreferrer nofollow" target="_blank">kenneth@edm8ker.com</a> 
 <br>9627 4987
 <br>
 </p>
@@ -97,7 +97,7 @@ course application via these links:</p>
 </td>
 <td rowspan="1" colspan="1">
 <p>Alan Wong
-<br><a href="mailto:alan.wong@gsatech.com.sg" rel="noopener noreferrer nofollow" target="_blank">alan.wong@gsatech.com.sg</a>
+<br><a href="mailto:alan.wong@gsatech.com.sg" rel="noopener noreferrer nofollow" target="_blank">alan.wong@gsatech.com.sg</a> 
 <br>9237 1090
 <br>
 </p>
@@ -113,7 +113,7 @@ course application via these links:</p>
 </td>
 <td rowspan="1" colspan="1">
 <p>Niki Lee
-<br><a href="mailto:niki.lee@sustainablelivinglab.org" rel="noopener noreferrer nofollow" target="_blank">niki.lee@sustainablelivinglab.org</a>
+<br><a href="mailto:niki.lee@sustainablelivinglab.org" rel="noopener noreferrer nofollow" target="_blank">niki.lee@sustainablelivinglab.org</a> 
 <br>8622 9317</p>
 </td>
 <td rowspan="1" colspan="1">
@@ -142,11 +142,11 @@ course application via these links:</p>
 </td>
 <td rowspan="1" colspan="1">
 <p>Philip Kong
-<br><a href="mailto:philipkong@zenitant.com.sg" rel="noopener noreferrer nofollow" target="_blank">philipkong@zenitant.com.sg</a>
+<br><a href="mailto:philipkong@zenitant.com.sg" rel="noopener noreferrer nofollow" target="_blank">philipkong@zenitant.com.sg</a> 
 <br>9744 0711
 <br>
 <br>Adrial Lai
-<br><a href="mailto:adriallai@zenitant.com.sg" rel="noopener noreferrer nofollow" target="_blank">adriallai@zenitant.com.sg</a>
+<br><a href="mailto:adriallai@zenitant.com.sg" rel="noopener noreferrer nofollow" target="_blank">adriallai@zenitant.com.sg</a> 
 <br>9232 5024</p>
 </td>
 <td rowspan="1" colspan="1">
@@ -161,7 +161,7 @@ course application via these links:</p>
 </td>
 <td rowspan="1" colspan="1">
 <p>Murtaza Njmudden
-<br><a href="mailto:murtaza@ducklearning.com" rel="noopener noreferrer nofollow" target="_blank">murtaza@ducklearning.com</a>
+<br><a href="mailto:murtaza@ducklearning.com" rel="noopener noreferrer nofollow" target="_blank">murtaza@ducklearning.com</a> 
 <br>9752 5201
 <br>
 </p>
@@ -182,11 +182,11 @@ course application via these links:</p>
 </td>
 <td rowspan="1" colspan="1">
 <p>Koh Choon Chuan
-<br><a href="mailto:cckoh@epasia.cc" rel="noopener noreferrer nofollow" target="_blank">cckoh@epasia.cc</a>
+<br><a href="mailto:cckoh@epasia.cc" rel="noopener noreferrer nofollow" target="_blank">cckoh@epasia.cc</a> 
 <br>9146 6015
 <br>
 <br>Gwenn Tan
-<br><a href="mailto:gwenntan@epasia.cc" rel="noopener noreferrer nofollow" target="_blank">gwenntan@epasia.cc</a>
+<br><a href="mailto:gwenntan@epasia.cc" rel="noopener noreferrer nofollow" target="_blank">gwenntan@epasia.cc</a> 
 <br>9800 7990
 <br>
 </p>
@@ -204,7 +204,7 @@ course application via these links:</p>
 </td>
 <td rowspan="1" colspan="1">
 <p>Brian Lee
-<br><a href="mailto:brianlee@roboto.sg" rel="noopener noreferrer nofollow" target="_blank">brianlee@roboto.sg</a>
+<br><a href="mailto:brianlee@roboto.sg" rel="noopener noreferrer nofollow" target="_blank">brianlee@roboto.sg</a> 
 <br>9767 8052
 <br>
 </p>
@@ -223,12 +223,12 @@ course application via these links:</p>
 </td>
 <td rowspan="1" colspan="1">
 <p>Thomas Yeo
-<br><a href="mailto:thomas.yeo@smet.edu.sg" rel="noopener noreferrer nofollow" target="_blank">thomas.yeo@smet.edu.sg</a>
+<br><a href="mailto:thomas.yeo@smet.edu.sg" rel="noopener noreferrer nofollow" target="_blank">thomas.yeo@smet.edu.sg</a> 
 <br>
 <br>Alex
-<br><a href="mailto:stagmatch@gmail.com" rel="noopener noreferrer nofollow" target="_blank">stagmatch@gmail.com</a>
+<br><a href="mailto:stagmatch@gmail.com" rel="noopener noreferrer nofollow" target="_blank">stagmatch@gmail.com</a> 
 <br>
-<br><a href="mailto:info@stagmatch.com.sg" rel="noopener noreferrer nofollow" target="_blank">info@stagmatch.com.sg</a>
+<br><a href="mailto:info@stagmatch.com.sg" rel="noopener noreferrer nofollow" target="_blank">info@stagmatch.com.sg</a> 
 <br>6612 7165
 <br>
 </p>

--- a/_infocomm-media-clubs-cca/LEARN: Tech and Media Courses/LEARN Roadmaps.md
+++ b/_infocomm-media-clubs-cca/LEARN: Tech and Media Courses/LEARN Roadmaps.md
@@ -3,42 +3,245 @@ title: LEARN Roadmaps
 permalink: /infocomm-media-clubs-cca/learn/roadmaps/
 description: LEARN Roadmaps
 third_nav_title: "LEARN: Tech and Media Courses"
+variant: tiptap
 ---
-## LEARN Roadmaps
-LEARN Roadmaps are structured, broad-based training courses held during CCA hours at MOE school premises. Specifically tailored for Infocomm Media Club students, these courses help develop basic skills in topics across tech and media domains such as Artificial Intelligence, Game Development and New Media.
-
-IMDA partners with industry leaders to develop industry-backed learning roadmaps to develop proficiency in the domain through the partners’ materials and platform. To cater to different interests, IMDA also offers tech and media courses in a broad spectrum of topics through our training partners.
-
-Each MOE school is supported with up to 2 courses annually, where the training cost is fully funded by IMDA. Where hardware is required, schools can work with the training providers or other vendors to procure the hardware at their own expense.
-
-[Download the Information Kit 2024 here.](https://go.gov.sg/learn-roadmaps-infokit24)
-
-##### Apply for the LEARN Roadmaps 2024
-
-The **application exercise for LEARN Roadmap 2024 will be held from 16 Oct 2023 to 31 Jan 2024**. Please download the Information Kit above, refer to the course details and follow the Application Process. <br><br>MOE HODs or Teachers-in-Charge of Infocomm Media Clubs can submit the course application via these links:
-
-* [Primary School](https://form.gov.sg/650955b1d5cb3e0011895695 )
-
-* [Secondary School / Junior College](https://form.gov.sg/650be1b6dc7011001165e2cc)
-
-Find out more about the LEARN Roadmap courses, by attending online sharing sessions hosted by our training providers from 19 October 2023 to 25 October 2023.<br>
-
-Please refer to the email blast sent on 16 October, for the links to the online sharing sessions. <br>For schools that did not receive the links, please write to -  [IMDA_Codesg@imda.gov.sg](mailto:IMDA_Codesg@imda.gov.sg)
-
-
-![](/images/icmclub/learn%20roadmaps%20process%202024(new).png)
-
-|**Training Provider**| **Contact Details** | **Courses Offered** |
-| -------- | -------- | -------- |
-|  **Make the Change** | Pedro Agurre<br>[pedro@makethechange.sg](mailto:pedro@makethechange.sg)<br> | • Immersive Media with APPLE (Primary) <br>• Immersive Media with APPLE (Secondary/JC) |
-|**edm8ker**| Kenneth Sim<br>[kenneth@edm8ker.com](mailto:kenneth@edm8ker.com)<br>9627 4987 <br> |• Social Robotics with UBTECH (Primary) |
-|**GSA**| Alan Wong<br>[alan.wong@gsatech.com.sg](mailto:alan.wong@gsatech.com.sg)<br>   9237 1090<br>|• Mobile App Development with GOOGLE (Primary) |
-|**Sustainable Living Lab**| Niki Lee<br>[niki.lee@sustainablelivinglab.org](mailto:niki.lee@sustainablelivinglab.org)<br>8622 9317|• Artificial Intelligence with INTEL<br>(Secondary / JC)|
-|**Tinkercademy**| Soon Yin Jie<br>[yjsoon@tinkertanker.com](mailto:yjsoon@tinkertanker.com) <br>8903 6700|• Mobile App Development with APPLE (Secondary/ JC)|
-|**Zenitant**| Philip Kong<br>[philipkong@zenitant.com.sg](mailto:philipkong@zenitant.com.sg)<br>9744 0711 <br><br>Hung Lin Lin<br>[linlin@zenitant.com.sg](mailto:linlin@zenitant.com.sg)<br>9232 5024|• Digital Making with MICROSOFT (Primary) <br>• Game Development with MICROSOFT (Primary) |
-|**Duck Learning**| Murtaza Njmudden<br>[murtaza@ducklearning.com](mailto:murtaza@ducklearning.com)<br>9752 5201<br>|• Game Development (Primary)<br>• Robotics (Primary)<br>• Artificial Intelligence(Secondary/JC)<br>• Data Analytics (Secondary/JC)<br>• Internet of Things (Secondary/JC)<br> • Robotics (Secondary/JC)|
-|**EP Education**| Koh Choon Chuan <br>[cckoh@epasia.cc](mailto:cckoh@epasia.cc)<br>9146 6015<br><br> Gwenn Tan<br>[gwenntan@epasia.cc](mailto:gwenntan@epasia.cc)<br>9800 7990<br>| • Artificial Intelligence (Primary) <br>• Artificial Intelligence (Secondary/JC)<br>• Internet of Things (Secondary/JC)|
-|**Roboto**| Brian Lee<br>[brianlee@roboto.sg](mailto:brianlee@roboto.sg)<br>9767 8052<br>|• Game Development (Primary)<br>• Mobile App Development (Primary)<br> • Robotics (Primary)<br> • Game Development (Secondary/JC)|
-|**Stag Match**|Thomas Yeo<br>[thomas.yeo@smet.edu.sg](mailto:thomas.yeo@smet.edu.sg)<br><br>Alex<br>[stagmatch@gmail.com](mailto:stagmatch@gmail.com)<br><br>[info@stagmatch.com.sg](mailto:info@stagmatch.com.sg)<br>6612 7165<br>| • Artificial Intelligence (Primary)<br>• Game Development (Secondary/JC)<br> • Robotics (Secondary/JC)|
-
-<br>Schools with queries or requesting more course/class support can write to [IMDA_Codesg@imda.gov.sg](mailto:IMDA_Codesg@imda.gov.sg)
+<h2>LEARN Roadmaps</h2>
+<p>LEARN Roadmaps are structured, broad-based training courses held during
+CCA hours at MOE school premises. Specifically tailored for Infocomm Media
+Club students, these courses help develop basic skills in topics across
+tech and media domains such as Artificial Intelligence, Game Development
+and New Media.</p>
+<p>IMDA partners with industry leaders to develop industry-backed learning
+roadmaps to develop proficiency in the domain through the partners’ materials
+and platform. To cater to different interests, IMDA also offers tech and
+media courses in a broad spectrum of topics through our training partners.</p>
+<p>Each MOE school is supported with up to 2 courses annually, where the
+training cost is fully funded by IMDA. Where hardware is required, schools
+can work with the training providers or other vendors to procure the hardware
+at their own expense.</p>
+<p><a href="https://go.gov.sg/learn-roadmaps-infokit24" rel="noopener noreferrer nofollow" target="_blank">Download the Information Kit 2024 here.</a>
+</p>
+<h5>Apply for the LEARN Roadmaps 2024</h5>
+<p>The&nbsp;application exercise for LEARN Roadmap 2024 has been <strong>extended to 29 Feb 2024</strong>.
+Please download the Information Kit above, refer to the course details
+and follow the Application Process.
+<br>
+<br>MOE HODs or Teachers-in-Charge of Infocomm Media Clubs can submit the
+course application via these links:</p>
+<ul>
+<li>
+<p><a href="https://form.gov.sg/650955b1d5cb3e0011895695" rel="noopener noreferrer nofollow" target="_blank">Primary School</a>
+</p>
+</li>
+<li>
+<p><a href="https://form.gov.sg/650be1b6dc7011001165e2cc" rel="noopener noreferrer nofollow" target="_blank">Secondary School / Junior College</a>
+</p>
+</li>
+</ul>
+<p></p>
+<div class="isomer-image-wrapper">
+<img style="width: 100%" height="auto" width="100%" alt="" src="/images/icmclub/learn%20roadmaps%20process%202024(new).png">
+</div>
+<table>
+<tbody>
+<tr>
+<th rowspan="1" colspan="1">
+<p><strong>Training Provider</strong>
+</p>
+</th>
+<th rowspan="1" colspan="1">
+<p><strong>Contact Details</strong>
+</p>
+</th>
+<th rowspan="1" colspan="1">
+<p><strong>Courses Offered</strong>
+</p>
+</th>
+</tr>
+<tr>
+<td rowspan="1" colspan="1">
+<p><strong>Make the Change</strong>
+</p>
+</td>
+<td rowspan="1" colspan="1">
+<p>Pedro Agurre
+<br><a href="mailto:pedro@makethechange.sg" rel="noopener noreferrer nofollow" target="_blank">pedro@makethechange.sg</a>
+<br>
+</p>
+</td>
+<td rowspan="1" colspan="1">
+<p>• Immersive Media with APPLE (Primary)
+<br>• Immersive Media with APPLE (Secondary/JC)</p>
+</td>
+</tr>
+<tr>
+<td rowspan="1" colspan="1">
+<p><strong>edm8ker</strong>
+</p>
+</td>
+<td rowspan="1" colspan="1">
+<p>Kenneth Sim
+<br><a href="mailto:kenneth@edm8ker.com" rel="noopener noreferrer nofollow" target="_blank">kenneth@edm8ker.com</a>
+<br>9627 4987
+<br>
+</p>
+</td>
+<td rowspan="1" colspan="1">
+<p>• Social Robotics with UBTECH (Primary)</p>
+</td>
+</tr>
+<tr>
+<td rowspan="1" colspan="1">
+<p><strong>GSA</strong>
+</p>
+</td>
+<td rowspan="1" colspan="1">
+<p>Alan Wong
+<br><a href="mailto:alan.wong@gsatech.com.sg" rel="noopener noreferrer nofollow" target="_blank">alan.wong@gsatech.com.sg</a>
+<br>9237 1090
+<br>
+</p>
+</td>
+<td rowspan="1" colspan="1">
+<p>• Mobile App Development with GOOGLE (Primary)</p>
+</td>
+</tr>
+<tr>
+<td rowspan="1" colspan="1">
+<p><strong>Sustainable Living Lab</strong>
+</p>
+</td>
+<td rowspan="1" colspan="1">
+<p>Niki Lee
+<br><a href="mailto:niki.lee@sustainablelivinglab.org" rel="noopener noreferrer nofollow" target="_blank">niki.lee@sustainablelivinglab.org</a>
+<br>8622 9317</p>
+</td>
+<td rowspan="1" colspan="1">
+<p>• Artificial Intelligence with INTEL
+<br>(Secondary / JC)</p>
+</td>
+</tr>
+<tr>
+<td rowspan="1" colspan="1">
+<p><strong>Tinkercademy</strong>
+</p>
+</td>
+<td rowspan="1" colspan="1">
+<p>Soon Yin Jie
+<br><a href="mailto:yjsoon@tinkertanker.com" rel="noopener noreferrer nofollow" target="_blank">yjsoon@tinkertanker.com</a> 
+<br>8903 6700</p>
+</td>
+<td rowspan="1" colspan="1">
+<p>• Mobile App Development with APPLE (Secondary/ JC)</p>
+</td>
+</tr>
+<tr>
+<td rowspan="1" colspan="1">
+<p><strong>Zenitant</strong>
+</p>
+</td>
+<td rowspan="1" colspan="1">
+<p>Philip Kong
+<br><a href="mailto:philipkong@zenitant.com.sg" rel="noopener noreferrer nofollow" target="_blank">philipkong@zenitant.com.sg</a>
+<br>9744 0711
+<br>
+<br>Adrial Lai
+<br><a href="mailto:adriallai@zenitant.com.sg" rel="noopener noreferrer nofollow" target="_blank">adriallai@zenitant.com.sg</a>
+<br>9232 5024</p>
+</td>
+<td rowspan="1" colspan="1">
+<p>• Digital Making with MICROSOFT (Primary)
+<br>• Game Development with MICROSOFT (Primary)</p>
+</td>
+</tr>
+<tr>
+<td rowspan="1" colspan="1">
+<p><strong>Duck Learning</strong>
+</p>
+</td>
+<td rowspan="1" colspan="1">
+<p>Murtaza Njmudden
+<br><a href="mailto:murtaza@ducklearning.com" rel="noopener noreferrer nofollow" target="_blank">murtaza@ducklearning.com</a>
+<br>9752 5201
+<br>
+</p>
+</td>
+<td rowspan="1" colspan="1">
+<p>• Game Development (Primary)
+<br>• Robotics (Primary)
+<br>• Artificial Intelligence(Secondary/JC)
+<br>• Data Analytics (Secondary/JC)
+<br>• Internet of Things (Secondary/JC)
+<br>• Robotics (Secondary/JC)</p>
+</td>
+</tr>
+<tr>
+<td rowspan="1" colspan="1">
+<p><strong>EP Education</strong>
+</p>
+</td>
+<td rowspan="1" colspan="1">
+<p>Koh Choon Chuan
+<br><a href="mailto:cckoh@epasia.cc" rel="noopener noreferrer nofollow" target="_blank">cckoh@epasia.cc</a>
+<br>9146 6015
+<br>
+<br>Gwenn Tan
+<br><a href="mailto:gwenntan@epasia.cc" rel="noopener noreferrer nofollow" target="_blank">gwenntan@epasia.cc</a>
+<br>9800 7990
+<br>
+</p>
+</td>
+<td rowspan="1" colspan="1">
+<p>• Artificial Intelligence (Primary)
+<br>• Artificial Intelligence (Secondary/JC)
+<br>• Internet of Things (Secondary/JC)</p>
+</td>
+</tr>
+<tr>
+<td rowspan="1" colspan="1">
+<p><strong>Roboto</strong>
+</p>
+</td>
+<td rowspan="1" colspan="1">
+<p>Brian Lee
+<br><a href="mailto:brianlee@roboto.sg" rel="noopener noreferrer nofollow" target="_blank">brianlee@roboto.sg</a>
+<br>9767 8052
+<br>
+</p>
+</td>
+<td rowspan="1" colspan="1">
+<p>• Game Development (Primary)
+<br>• Mobile App Development (Primary)
+<br>• Robotics (Primary)
+<br>• Game Development (Secondary/JC)</p>
+</td>
+</tr>
+<tr>
+<td rowspan="1" colspan="1">
+<p><strong>Stag Match</strong>
+</p>
+</td>
+<td rowspan="1" colspan="1">
+<p>Thomas Yeo
+<br><a href="mailto:thomas.yeo@smet.edu.sg" rel="noopener noreferrer nofollow" target="_blank">thomas.yeo@smet.edu.sg</a>
+<br>
+<br>Alex
+<br><a href="mailto:stagmatch@gmail.com" rel="noopener noreferrer nofollow" target="_blank">stagmatch@gmail.com</a>
+<br>
+<br><a href="mailto:info@stagmatch.com.sg" rel="noopener noreferrer nofollow" target="_blank">info@stagmatch.com.sg</a>
+<br>6612 7165
+<br>
+</p>
+</td>
+<td rowspan="1" colspan="1">
+<p>• Artificial Intelligence (Primary)
+<br>• Game Development (Secondary/JC)
+<br>• Robotics (Secondary/JC)</p>
+</td>
+</tr>
+</tbody>
+</table>
+<p>
+<br>Schools with queries or requesting more course/class support can write
+to <a href="mailto:IMDA_Codesg@imda.gov.sg" rel="noopener noreferrer nofollow" target="_blank">IMDA_Codesg@imda.gov.sg</a>
+</p>


### PR DESCRIPTION
Hi Diana,

Pull request submitted to amend LEARN Roadmaps webpage.

1) Apply for the LEARN Roadmaps 2024
The application exercise for LEARN Roadmap 2024 has been extended to 29 Feb 2024. Please download the Information Kit above, refer to the course details and follow the Application Process.
MOE HODs or Teachers-in-Charge of Infocomm Media Clubs can submit the course application via these links:
•	Primary School
•	Secondary School / Junior College

2) Zenitant
Philip Kong
philipkong@zenitant.com.sg
9744 0711

Adrial Lai
adriallai@zenitant.com.sg 
9232 5024

Thank you.

Winson 